### PR TITLE
Issue #13 - setup codeowners file

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,0 +1,3 @@
+#These owners will be responsible for reviewing pull requests for all file types
+
+* @princiya @therealpadams @perploug


### PR DESCRIPTION
This ensures open source team members are automatically assigned as reviewers.