### PR TITLE
Github membership structure proposal

### DIFF
--- a/resources/github-org-proposal.md
+++ b/resources/github-org-proposal.md
@@ -3,15 +3,24 @@
 This document outlines the proposed new structure for all teams and projects on the Zalando and Zalando-Incubator
 organisations. 
 
-There are 2 possible solutions, each with their own pros and cons. 
 
-
-# Model 1 - organisation membership
+# Organisation membership
 Model supports the current structure, but enforces guidelines for how teams should work
+
+- Zalando employees are members of the organisation
+- Small number of owners
+- By default members only have read-only access
+
+#### Pros
+- Handle permissions on a team basis
+- Enforces git flow for internal and external contribs
+- Clearly seperates Zalando Employees from externals
+
+#### Cons
+- Exposes all org members in reviews - this can be handled to some extend with CODEOWNERS
 
 ## Organisations
 No Changes required, Zalando and Zalando-Incubator keep their current purpose and the same types of projects are hosted within them - longer term a set of guidelines for incubator graduation will be produced. 
-
 
 ### Org security
 - Only the Open Source team along with very few additional people should be org owners
@@ -22,15 +31,16 @@ No Changes required, Zalando and Zalando-Incubator keep their current purpose an
 - 2FA is enabled
 - All legacy admin teams are migrated to member status
 
-
 ## Team Structure
 - Current team structure can be re-used, but it provides no value in its current state
 - Use teams to give access to repositories instead of individuals
+- Only teams that actually have oss projects on github should be created
 - Recreate the Zalando team structure so it reflects the organisation
 
 - Fashion-store
     - Search
         - Taxonomy 
+        - etc
 
 - Give teams descriptions based on what they do
     - Increases visibility internally and externally who does what
@@ -41,14 +51,30 @@ No Changes required, Zalando and Zalando-Incubator keep their current purpose an
 - Team members have write access to their own repos, so everyone in a team can approve pull requests and merge them in (if approved)
 
 
+## External Collaborators
+- Externals have read access to repos 
+    - r.o.p dictates 2 set of zalando eyes approves all PRs
+    - externals can have write access, but that will require that all pull requests are forced approved by zalando devs - so externals cannot be part of CODEOWNERS
+
+
 ## Repository permissions
 - Master branch is proctected, all changes must be through a pull request
     - Also for admins
-- Pull requests must be approved by 2 members of the team
+- Pull requests must be approved by 2 codeowners
 - CODEOWNERS file is used to assign appropriate reviewers automatically
+- Checks for CDO and policy and performed automatically
+    - CDObot can check for signed comiits
+    - Zappr can do policy checks - altho it does not seemed used atm
+
+
+
+## Pull Requests
+- All pull requests are made from a fork, not within the repository
+- As soon as work start on a change, a pull request is opened (template available)
+- A new pull request is marked with the label `pr: work in progress`
+- When work has completed, the `pr: work in progress` is removed and the team is pinged 
+- Pull request is marked with appropriate labels for type of work - avoid acronyms
+- Pull request is automatically assigned reviewers from CODEOWNERS
 
 
 ----- 
-
-
-# Model 2 - external contributor model

--- a/resources/github-org-proposal.md
+++ b/resources/github-org-proposal.md
@@ -1,74 +1,92 @@
 # Proposed Zalando Github Structure
 
-This document outlines the proposed new structure for all teams and projects on the Zalando and Zalando-Incubator
-organisations. 
+This document outlines the proposed new structure for all teams and projects on the Zalando, Zalando-Incubator, Zalando-Stups, Zalando-Nakadi organisations. 
+
+**note:** This structure is currently not possible to apply to enterprise github due to missing features
+in the enterprise version - however, the long term goal is to align way of working between the
+2 environments. 
 
 
-# Organisation membership
-Model supports the current structure, but enforces guidelines for how teams should work
+# TL;DR
+Model supports the current organisation structure, but enforces guidelines for how teams should work
 
 - Zalando employees are members of the organisation
-- Small number of owners
-- By default members only have read-only access
+- Small number of owners / admins
+- By default members only have read-only access to repose
+- Project maintainers have write access to their projects through project team permissions
+- Everyone can fork and contribute to all organisation projects
+- Repository permissions enforces git flow and code reviews
 
-#### Pros
+### Pros
 - Handle permissions on a team basis
 - Enforces git flow for internal and external contribs
 - Clearly seperates Zalando Employees from externals
 
-#### Cons
-- Exposes all org members in reviews - this can be handled to some extend with CODEOWNERS
+### Cons
+- Exposes all organisation members in reviews - this can be handled to some extend with CODEOWNERS files
+
+----- 
+
+
+# Detailed version
 
 ## Organisations
-No Changes required, Zalando and Zalando-Incubator keep their current purpose and the same types of projects are hosted within them - longer term a set of guidelines for incubator graduation will be produced. 
+No Changes required, all organisations  keep their current purpose and the same types of projects are hosted within them - longer term a set of guidelines for zalando-incubator graduation will be produced. 
 
-### Org security
-- Only the Open Source team along with very few additional people should be org owners
-- Org members have read permissions by default
-- Limited number of Org Admins
+### organisation security
+- Only the Open Source team along with very few additional people should be organisation owners
+- organisation members have read permissions by default
+- Limited number of organisation Admins
 - Members are not allowed to create repositories
 - Members are not allowed to delete, rename or publicize repos
 - 2FA is enabled
 - All legacy admin teams are migrated to member status
 
+
 ## Team Structure
-- Current team structure can be re-used, but it provides no value in its current state
+- Current team structure provides no value in its current state
 - Use teams to give access to repositories instead of individuals
 - Only teams that actually have oss projects on github should be created
-- Recreate the Zalando team structure so it reflects the organisation
 
-- Fashion-store
-    - Search
-        - Taxonomy 
-        - etc
+```
+- Admin / Janitorial Teams
+    - Open Source Team
+    - Developer Productivity
+
+- Project Teams
+    - Team-Nakadi
+    - Team-Skipper 
+    - Team-etc
+```
 
 - Give teams descriptions based on what they do
-    - Increases visibility internally and externally who does what
+- Increases visibility internally and externally who does what
 
 
 ### Team permissions
-- Teams by default have read access to all repos, so everyone can open a pull request from their own fork
-- Team members have write access to their own repos, so everyone in a team can approve pull requests and merge them in (if approved)
+- Teams are for project maintainers only and teams have write acccess to their project
+- Only Zalando Employees are member of teams
+- Team sizes should not be beyond 2-3 people, and should not be automated
 
 
 ## External Collaborators
-- Externals have read access to repos 
+- Externals have read access to repositories 
     - r.o.p dictates 2 set of zalando eyes approves all PRs
     - externals can have write access, but that will require that all pull requests are forced approved by zalando devs - so externals cannot be part of CODEOWNERS
-
 
 ## Repository permissions
 - Master branch is proctected, all changes must be through a pull request
     - Also for admins
 - Pull requests must be approved by 2 codeowners
 - CODEOWNERS file is used to assign appropriate reviewers automatically
+- Enforce reviews from CODEOWNERS - this replaces Zapprs team+organisation based review enforcement
 - Checks for CDO and policy and performed automatically
     - CDObot can check for signed comiits
-    - Zappr can do policy checks - altho it does not seemed used atm
 
-## Branching and pull requests
-- Follow github flow
-- Create an issue or pick and existing issue
+
+## Branching and pull request process
+- Follow git flow
+- Create an issue or pick an existing issue
 - Create a fork
 - Create a topic branch for the specific feature ex: `website-header`
 - Open a pull request outlining changes
@@ -85,7 +103,3 @@ No Changes required, Zalando and Zalando-Incubator keep their current purpose an
 - CODEOWNERS will approve and merge changes
 - Mark issue as closed
 - Delete branch
-
-
-
------ 

--- a/resources/github-org-proposal.md
+++ b/resources/github-org-proposal.md
@@ -1,0 +1,54 @@
+# Proposed Zalando Github Structure
+
+This document outlines the proposed new structure for all teams and projects on the Zalando and Zalando-Incubator
+organisations. 
+
+There are 2 possible solutions, each with their own pros and cons. 
+
+
+# Model 1 - organisation membership
+Model supports the current structure, but enforces guidelines for how teams should work
+
+## Organisations
+No Changes required, Zalando and Zalando-Incubator keep their current purpose and the same types of projects are hosted within them - longer term a set of guidelines for incubator graduation will be produced. 
+
+
+### Org security
+- Only the Open Source team along with very few additional people should be org owners
+- Org members have read permissions by default
+- Limited number of Org Admins
+- Members are not allowed to create repositories
+- Members are not allowed to delete, rename or publicize repos
+- 2FA is enabled
+- All legacy admin teams are migrated to member status
+
+
+## Team Structure
+- Current team structure can be re-used, but it provides no value in its current state
+- Use teams to give access to repositories instead of individuals
+- Recreate the Zalando team structure so it reflects the organisation
+
+- Fashion-store
+    - Search
+        - Taxonomy 
+
+- Give teams descriptions based on what they do
+    - Increases visibility internally and externally who does what
+
+
+### Team permissions
+- Teams by default have read access to all repos, so everyone can open a pull request from their own fork
+- Team members have write access to their own repos, so everyone in a team can approve pull requests and merge them in (if approved)
+
+
+## Repository permissions
+- Master branch is proctected, all changes must be through a pull request
+    - Also for admins
+- Pull requests must be approved by 2 members of the team
+- CODEOWNERS file is used to assign appropriate reviewers automatically
+
+
+----- 
+
+
+# Model 2 - external contributor model

--- a/resources/github-org-proposal.md
+++ b/resources/github-org-proposal.md
@@ -66,15 +66,26 @@ No Changes required, Zalando and Zalando-Incubator keep their current purpose an
     - CDObot can check for signed comiits
     - Zappr can do policy checks - altho it does not seemed used atm
 
+## Branching and pull requests
+- Follow github flow
+- Create an issue or pick and existing issue
+- Create a fork
+- Create a topic branch for the specific feature ex: `website-header`
+- Open a pull request outlining changes
+    - include a what + why description
+    - include a list of tasks to complete this pull request
+    - include expected delivery
+    - Pull request is automatically assigned reviewers from CODEOWNERS
+    - Mark Pull request with appropriate labels for type of work - avoid acronyms
+    - add `work in progress` label
+- Make commits
+- Remove `work in progress` label
+- Notify CODEOWNERS of completed pull request via pull request message
+- Participate in code review and discuss changes
+- CODEOWNERS will approve and merge changes
+- Mark issue as closed
+- Delete branch
 
-
-## Pull Requests
-- All pull requests are made from a fork, not within the repository
-- As soon as work start on a change, a pull request is opened (template available)
-- A new pull request is marked with the label `pr: work in progress`
-- When work has completed, the `pr: work in progress` is removed and the team is pinged 
-- Pull request is marked with appropriate labels for type of work - avoid acronyms
-- Pull request is automatically assigned reviewers from CODEOWNERS
 
 
 ----- 

--- a/resources/github-org-proposal.md
+++ b/resources/github-org-proposal.md
@@ -1,6 +1,6 @@
 # Proposed Zalando Github Structure
 
-This document outlines the proposed new structure for all teams and projects on the Zalando, Zalando-Incubator, Zalando-Stups, Zalando-Nakadi organisations. 
+This document outlines the proposed new structure for all teams and projects on the Zalando, Zalando-Incubator, Zalando-Stups, Zalando-Nakadi and Zalando-Zmon organisations. 
 
 **note:** This structure is currently not possible to apply to enterprise github due to missing features
 in the enterprise version - however, the long term goal is to align way of working between the
@@ -39,7 +39,7 @@ No Changes required, all organisations  keep their current purpose and the same 
 - Limited number of organisation Admins
 - Members are not allowed to create repositories
 - Members are not allowed to delete, rename or publicize repos
-- 2FA is enabled
+- 2FA is enforced
 - All legacy admin teams are migrated to member status
 
 


### PR DESCRIPTION
Document outline membership, organisation and workflow changes to the zalando organisations
on github

## Tasks

  - [x] outline orgs
  - [x] outline teams + permissions
  - [x] outline repos + repo/branching permissions
  - [x] outline member default permissions
  - [x] branching guidelines
  - [x] pull request guidelines
  - [x] labelling guidelines 

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply:_

- [ ] My change requires a change to the documentation & I have updated it accordingly.
