### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-opensource.zalando.com


### PR DESCRIPTION
Deleting the CNAME file temporarily until the DNS is resolved to point to opensource.zalando.com. This otherwise breaks all other pages served from zalando.github.io, example, dress-code.