### PR TITLE
Error handling when catwatch fails

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -10,7 +10,7 @@ banner:
 
     <div id="catwatch-statistics" class="statistics"></div>
 
-    <div class="projects__wrapper">
+    <div class="projects__wrapper" id="projectsWrapper">
       <div class="spinner-overlay" id="spinner">
         <div class="dc-spinner"></div>
       </div>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -21,7 +21,7 @@ banner:
       </div>
     </div>
 
-    <div class="projects__wrapper">
+    <div class="projects__wrapper" id="projectsWrapper">
       <div class="spinner-overlay" id="spinner">
         <div class="dc-spinner"></div>
       </div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,11 @@
 async function getData(url) {
-  const response = await fetch(url);
-  return await response.json();
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } catch (e) {
+    hideSpinner();
+    console.log(e);
+  }
 }
 
 async function getProjects(organisation, language) {
@@ -46,7 +51,13 @@ function renderProjects(projects, isShowAll = true) {
     });
   }
 
-  render('catwatch-projects', [...projectsToDisplay].join(''));
+  if (projectsToDisplay.size > 0) {
+    render('catwatch-projects', [...projectsToDisplay].join(''));
+  } else {
+    render('catwatch-projects', 'We could not fetch projects at the moment. Please try again later!');
+    const projectsWrapper = document.getElementById('projectsWrapper');
+    projectsWrapper.style.minHeight = '50px';
+  }
   hideSpinner();
 }
 
@@ -140,12 +151,15 @@ function hideSpinner() {
 
 async function displayStatistics() {
   const response = await getData(api.statistics);
-  const data = response[0];
-  store.totalProjects = data.publicProjectCount;
+  if (response) {
+    const data = response[0];
 
-  const statistics = [];
-  statistics.push(statistic(data));
-  render('catwatch-statistics', statistics.join(''));
+    store.totalProjects = data.publicProjectCount;
+
+    const statistics = [];
+    statistics.push(statistic(data));
+    render('catwatch-statistics', statistics.join(''));
+  }
 };
 
 async function displayTeam() {


### PR DESCRIPTION
## Description

If Catwatch fails, then the following text is displayed as a placeholder: 

"We could not fetch projects at the moment. Please try again later"

## Types of Changes

- Refactor/improvements

## Tasks

  - [x] try catch block added