### PR TITLE
DOCS removed from header

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -61,7 +61,7 @@
             <li><a href="/index.html#os-projects">Projects</a></li>
             <li><a href="/index.html#os-goals">Purpose</a></li>
             <li><a href="/index.html#os-jobs">Jobs</a></li>
-            <li><a href="/index.html#os-articles">Articles</a></li>
+            <li><a href="/index.html#os-articles">Blog</a></li>
             <li><a href="/index.html#os-team">Team</a></li>
           </ul>
         </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
       {% if include.title == "Docs" or page.layout == 'documentation' %}
       <!-- <li class="dc-tab__element dc-tab__element--active"><a href="/docs">Docs</a></li> -->
       {% else %}
-      <li class="dc-tab__element"><a href="/docs">Docs</a></li>
+      <!--<li class="dc-tab__element"><a href="/docs">Docs</a></li>-->
       {% endif %}
       <li class="dc-tab__element"><a href="/index.html#os-team">Team</a></li>
     </ul>


### PR DESCRIPTION
## Description

We need to hide `Docs` from the header menu until we have the real docs in place. In this PR, `Docs` is commented out from the `if` clause as well.

## Tasks

- [x] Docs commented out from the header menu
- [x] Articles renamed to Blog in the footer

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
