### PR TITLE
Removed banner for docs

### DIFF
--- a/_docs/using/how-to-oss.md
+++ b/_docs/using/how-to-oss.md
@@ -6,6 +6,8 @@ banner:
   image: coding.jpg
 category: Using
 ---
+# How to OSS at Zalando
+
 At Zalando, we have many teams working on their respective systems and domains where they operate like small startups. They take responsibility for these systems and have a feeling of ownership, constantly engaging with other teams to solve bigger challenges and enable new features.
 
 Sometimes during these alignments and feature requests, priorities collide and we can’t support others. In these situations, we aim for an InnerSource approach to address the required changes. This means that much like open source projects, the requesting team must implement the necessary changes in other components and the owner of these components has to review and approve the changes. This way, the impact on the owning team is minimal and the requesting team is not blocked.

--- a/_docs/using/how-to-oss.md
+++ b/_docs/using/how-to-oss.md
@@ -6,8 +6,6 @@ banner:
   image: coding.jpg
 category: Using
 ---
-# How to OSS at Zalando
-
 At Zalando, we have many teams working on their respective systems and domains where they operate like small startups. They take responsibility for these systems and have a feeling of ownership, constantly engaging with other teams to solve bigger challenges and enable new features.
 
 Sometimes during these alignments and feature requests, priorities collide and we can’t support others. In these situations, we aim for an InnerSource approach to address the required changes. This means that much like open source projects, the requesting team must implement the necessary changes in other components and the owner of these components has to review and approve the changes. This way, the impact on the owning team is minimal and the requesting team is not blocked.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,9 @@
   <body>
     {% include header.html title=page.title %}
 
-    {% include banner.html %}
+    {% if include.title != "Docs" and page.layout != 'documentation' %}
+      {% include banner.html %}
+    {% endif %}
 
     <main>
       {{content}}

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -5,6 +5,8 @@ layout: default
   <div class="dc-container dc-container--limited article documentation">
     <div class="article__content">
       <div class="dc-column__contents dc-column__contents--center">
+        <h1>{{ page.title }}</h1>
+
         {{content}}
       </div>
     </div>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<section class="page-section page-section--padding">
+<section class="page-section page-section--padding page-section--border-top">
   <div class="dc-container dc-container--limited article documentation">
     <div class="article__content">
       <div class="dc-column__contents dc-column__contents--center">

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -42,7 +42,7 @@
 
 .article a:hover,
 .tree__list-item--active a {
-  box-shadow: inset 0 -2px 0 0 var(--primary-font-color);
+  box-shadow: inset 0 -2px 0 0 var(--zalando-orange);
 }
 
 .article__sidebar {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -114,6 +114,10 @@ body li {
   border-bottom: 1px solid var(--page-section-border);
 }
 
+.page-section--border-top {
+  border-top: 1px solid var(--page-section-border);
+}
+
 .page-section__header {
   position: relative;
 }


### PR DESCRIPTION
Issue: #68

## Description

The banner image header is removed from docs pages and a simple h1 headline is used instead.

## Types of Changes

- Refactor/improvements

## Tasks

  - [x] Removed banner header image
  - [x] Updated underline color for sidebar links

## Screenshot

![zalando open source how to oss at zalando](https://user-images.githubusercontent.com/8022693/40830063-9b2ad422-6585-11e8-8dd3-ef002986ac28.png)
