### PR TITLE
Disabling the docs section for further QA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     activesupport (4.2.9)
       i18n (~> 0.7)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
       </li>
       
       <li class="dc-tab__element {% if page.path == '_pages/projects.md' %}dc-tab__element--active {% endif %}"><a href="/projects">Projects</a></li>
-      <li class="dc-tab__element {% if page.collection == "docs" %}dc-tab__element--active{% endif %}"><a href="/docs">Docs</a></li>
+      <!-- li class="dc-tab__element {% if page.collection == "docs" %}dc-tab__element--active{% endif %}"><a href="/docs">Docs</a></li -->
       
       <li class="dc-tab__element {% if page.collection == "posts" %}dc-tab__element--active{% endif %}"><a href="/blog">Blog</a></li>
       <li class="dc-tab__element"><a href="/#os-goals">Purpose</a></li>


### PR DESCRIPTION
Signed-off-by: Paul Adams <paul@baggerspion.net>

## Description

This PR disables docs in the website because of two serious issues:
- Docs are incorrectly styled (content assuming full width of the page)
- 404s - notably in the landing page of the "using" section

## Types of Changes

- Refactor/improvements