### PR TITLE
Documentation sample of a sign-off git hook

### DIFF
--- a/_docs/releasing/contributions.md
+++ b/_docs/releasing/contributions.md
@@ -38,13 +38,22 @@ To encourage contributions, you must provide a clear guide for how contributions
 Git sign-off can be done by adding the `-s` flag to `git commit` commands. However non-commandline tooling often doesn't support this, in which case you can add a git hook to ensure your commits are signed - in the [global .git-hooks folder](https://github.com/git-hooks/git-hooks/wiki/Get-Started) add a file named `prepare-commit-msg`, add the following and ensure it has rights to execute: 
 
 ```
-Promise.all(result).then(function(result) {
-    for (const res of result) {
-      table.push(res);
-    }
+#!/bin/sh
 
-    config = {};
-    console.log(table.toString());
-    cb();
-  });
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"
 ```

--- a/_docs/releasing/contributions.md
+++ b/_docs/releasing/contributions.md
@@ -33,3 +33,18 @@ To encourage contributions, you must provide a clear guide for how contributions
 * Document the PR review process
 * Have a clear vision and scope for your project
 * Be responsive to issues and pull requests, even if it's to decline them
+
+### Automatic git sign-off
+Git sign-off can be done by adding the `-s` flag to `git commit` commands. However non-commandline tooling often doesn't support this, in which case you can add a git hook to ensure your commits are signed - in the [global .git-hooks folder](https://github.com/git-hooks/git-hooks/wiki/Get-Started) add a file named `prepare-commit-msg`, add the following and ensure it has rights to execute: 
+
+```
+Promise.all(result).then(function(result) {
+    for (const res of result) {
+      table.push(res);
+    }
+
+    config = {};
+    console.log(table.toString());
+    cb();
+  });
+```


### PR DESCRIPTION
Update to the contribution documentation on how to add a global git-hook to manage git sign-off in case tooling is used which does not support sign-off by default (like github desktop) 
