### PR TITLE
Remove broken banner

### DIFF
--- a/_posts/2018-11-05-connexion-20-release.md
+++ b/_posts/2018-11-05-connexion-20-release.md
@@ -2,8 +2,6 @@
 title: Connexion 2.0 Release
 author: João Santos
 date: 2018-11-05
-banner:
-  image: connected.jpg
 ---
 
 Today we released [Connexion](https://github.com/zalando/connexion) 2.0 with OpenAPI 3 support.


### PR DESCRIPTION
Signed-off-by: Paul Adams <paul@baggerspion.net>

## Description

For now removes the broken banner image and falls back to the default.
"connected.jpg" seems to be somehow corrupted and stopping builds on the GH side.

## Types of Changes

_What types of changes does your code introduce? remove the points which aren't applicable:_

- Bug fix (non-breaking change which fixes an issue)

## Tasks
  - [x] Removed reference to broken jpg in the source of the blog post
  - [ ] Replace the image 
  - [ ] Replace the reference in the blog post
