### PR TITLE
Atom feed with the PostgreSQL tag

### DIFF
--- a/_posts/2018-11-26-postgres-operator.md
+++ b/_posts/2018-11-26-postgres-operator.md
@@ -3,6 +3,7 @@ title: "Zalando Postgres Operator: One Year Later"
 author: Sergey Dudoladov 
 date: 2018-11-26
 tags: [PostgreSQL]
+short: "The Postgres operator provides a managed Postgres service for Kubernetes. It extends the Kubernetes API with a custom “postgresql” resource that describes desired characteristics of a Postgres cluster, monitors updates of this resource and adjusts Postgres clusters accordingly. Zalando successfully uses the operator to manage more than 450 Postgres clusters across a large number of Kubernetes installations."
 banner:
   image: scale.jpg
 ---

--- a/_posts/2018-11-26-postgres-operator.md
+++ b/_posts/2018-11-26-postgres-operator.md
@@ -2,6 +2,7 @@
 title: "Zalando Postgres Operator: One Year Later" 
 author: Sergey Dudoladov 
 date: 2018-11-26
+tags: [PostgreSQL]
 banner:
   image: scale.jpg
 ---

--- a/blog/tags/PostgreSQL/atom.xml
+++ b/blog/tags/PostgreSQL/atom.xml
@@ -1,0 +1,33 @@
+---
+layout: nil
+---
+
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+ <title>{{ site.title }}</title>
+ <link href="{{ site.url }}/blog/tags/PostgreSQL/atom.xml" rel="self"/>
+ <link href="{{ site.url }}/"/>
+ <updated>{{ site.time | date_to_xmlschema }}</updated>
+ <id>{{ site.url }}</id>
+
+ {% for post in site.posts %}
+     {% for tag in post.tags %}
+     {% if tag == "PostgreSQL" %}
+         <entry>
+           <title>{{ post.title }}</title>
+           <link href="{{ site.url }}{{ post.url }}"/>
+           <updated>{{ post.date | date_to_xmlschema }}</updated>
+           <id>{{ site.url }}{{ post.id }}</id>
+           <author>
+             <name>{{ post.author.name }}</name>
+           </author>
+           <content type="html">
+             {{ post.content | markdownify | truncatewords: 20 }}
+           </content>
+         </entry>
+     {% endif %}
+     {% endfor %}
+ {% endfor %}
+
+</feed>

--- a/blog/tags/PostgreSQL/atom.xml
+++ b/blog/tags/PostgreSQL/atom.xml
@@ -23,7 +23,7 @@ layout: nil
              <name>{{ post.author.name }}</name>
            </author>
            <content type="html">
-             {{ post.content | markdownify | truncatewords: 20 }}
+             {{ post.content | truncatewords: 20 }}
            </content>
          </entry>
      {% endif %}

--- a/blog/tags/PostgreSQL/atom.xml
+++ b/blog/tags/PostgreSQL/atom.xml
@@ -22,9 +22,7 @@ layout: nil
            <author>
              <name>{{ post.author.name }}</name>
            </author>
-           <content type="html">
-             {{ post.content | truncatewords: 20 }}
-           </content>
+           <content type="html">{{ post.short }}</content>
          </entry>
      {% endif %}
      {% endfor %}

--- a/blog/tags/PostgreSQL/index.html
+++ b/blog/tags/PostgreSQL/index.html
@@ -1,0 +1,4 @@
+---
+layout: landing
+tag: PostgreSQL
+---


### PR DESCRIPTION
Issue: #350  

## Description

Add atom.xml template to generate an rss feed with tags (so far only for PostgreSQL, can be adjusted for anything). Produces the following result so far:

```xml
<feed xmlns="http://www.w3.org/2005/Atom">
<title>Zalando Open Source</title>
<link href="https://opensource.zalando.com/blog/tags/PostgreSQL/atom.xml" rel="self"/>
<link href="https://opensource.zalando.com/"/>
<updated>2018-12-19T12:18:20+00:00</updated>
<id>https://opensource.zalando.com</id>
<entry>
<title>Zalando Postgres Operator: One Year Later</title>
<link href="https://opensource.zalando.com/blog/2018/11/postgres-operator/"/>
<updated>2018-11-26T00:00:00+00:00</updated>
<id>
https://opensource.zalando.com/blog/2018/11/postgres-operator
</id>
<author>
<name/>
</author>
<content type="html">
The Postgres operator provides a managed Postgres service for Kubernetes. It extends the Kubernetes API with a custom “postgresql” resource that describes desired characteristics of a Postgres cluster, monitors updates of this resource and adjusts Postgres clusters accordingly. Zalando successfully uses the operator to manage more than 450 Postgres clusters across a large number of Kubernetes installations.
</content>
</entry>
</feed>
```

Requires to have a new field "short" with a short description of an article.