### PR TITLE
Create harassment-policy.md

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -25,3 +25,6 @@ This website is therefore a guide, primarily for Zalando employees, on how to ad
   
 - [State of open source at Zalando 2018 Report]({{ "docs/reports/2019/january-2019" | relative_url}})
   The 2018 report on how open source is doing at Zalando with key numbers and insights, as well as a roadmap forward
+
+- [Harassment Policy]({{"docs/resources/harassment-policy" | relative_url }})
+  Policy on how we manage online harassment and support our maintainers and contributors as when working with open source as part of their work at Zalando. 

--- a/_docs/resources/harassment-policy.md
+++ b/_docs/resources/harassment-policy.md
@@ -1,0 +1,28 @@
+---
+title: Harassment Policy
+author: OST
+date: 2019-01-31
+index: 5
+category: Resources
+---
+
+#### When you as a Zalando employee engage in open source communities as part of your work, you will interact with the wider open source communities outside Zalando - this is generally a good experience and collaborating with many different types of developers with different backgrounds is generally a positive input to your personal development. 
+
+However, it also means there is a risk that you might encounter abusive or harassing behavior from people in the communities around these projects - it happens very rarely, but if you are ever exposed to such behavior, be aware that Zalando as your employer are here to assist you.
+
+Zalando takes online harassment seriously and will take the required actions to protect its employees from harm when they engage in open source work on the company's behalf.
+
+## Proactive measures
+We require all new projects released by Zalando to adopt and enforce a code of conduct and it is the responsibility of all Zalandos to follow this conduct. We also recommend you investigate whether external projects you interact enforces a code of conduct - we recommend using the [contributor covenant](https://www.contributor-covenant.org/) available in our [repository boilerplate](https://github.com/zalando-incubator/new-project/).
+
+All Zalando open source maintainers are obligated to act on and report abusive behavior to the [open source team](opensource@zalando.de). 
+
+In cases of harassment in our open source projects we collaborate with the GitHub community team to protect our maintainers and community members.
+
+## Support in case of harassment
+If you are ever exposed to harassment or abusive behavior, be aware that Zalando can assist you with the following:
+
+1. P&O can guide you on how to react to abusive behavior and help you determine if legal action is required. Talk to your lead if you need assistance, or reach out directly to the open source team or discrimination@zalando.de. 
+2. The [open source team](opensource@zalando.de) will assist you in reporting the abuse to the responsible platform owner (such as Github)
+3. Zalando legal will provide legal guidance in case such is required
+4. If it is established there is a need to report the incident to law enforcement, P&O and Zalando legal will assist you in collecting evidence and file a report


### PR DESCRIPTION
Harassment policy for zalando open source maintainers and contributors. 

This policy outlines the actions which Zalando will take to deal with online harassment and how we support employees who encounter such behavior. 

Signed-off-by: Per Ploug <per.ploug@zalando.de>

Issue: #376 

## Description

This PR adds a policy document and a link to the docs overview for visibility.


