### PR TITLE
Update dead link to Drs. Dirk Riehle's paper

### DIFF
--- a/_docs/resources/innersource-howto.md
+++ b/_docs/resources/innersource-howto.md
@@ -51,4 +51,4 @@ There's a growing number of useful resources on InnerSource. Here are a few:
 - [Adopting Open Source Development Practices in Organizations: A Tutorial](http://ieeexplore.ieee.org/document/6809709/) by the IEEE (requires sign-in)
 - [InnerSource Commons](https://paypal.github.io/InnerSourceCommons/) website
 - [Inner Source in Platform-Based Product
-Engineering](http://www.develop-group.de/fileadmin/dg_Internet/downloads/Fachveroeffentlichungen/Fachveroeffentlichungen_Projekt/devgroup_InnerSource_in_Platform-BasedProductEngineering.pdf) by Drs. Dirk Riehle, Maximilian Capraro, Detlef Kips, Lars Horn
+Engineering](https://dirkriehle.com/wp-content/uploads/2016/06/riehle-capraro-horn-kips-inner-source-in-product-line-engineering-platform-based-products.pdf) by Drs. Dirk Riehle, Maximilian Capraro, Detlef Kips, Lars Horn


### PR DESCRIPTION
## Description

The link to Drs. Dirk Riehle's paper, Inner Source in Platform-Based Product
Engineering, was dead.

NOTE : Since I never saw the previously linked document, can you confirm that I linked to the same one, as intended.

Thanks for your documentation about OpenSource & InnerSource.
It is a great source of inspiration to start changes at my workplace.

Issue: #399 