### PR TITLE
add lightbend CLA to the whitelist

### DIFF
--- a/_docs/using/contributing.md
+++ b/_docs/using/contributing.md
@@ -60,5 +60,6 @@ If a non-Zalando open source project asks you to sign a contributor agreement, g
 - Google iCLA
 - Developer Certificate Of Origin
 - Pivotal CLA
+- Lightbend CLA
 
 


### PR DESCRIPTION
Lightbend CLA is cleared and it is fine to use it.

Signed-off-by: Tuomas Lappeteläinen <tuomas.lappetelainen@gmail.com>

Issue: #409 
