### PR TITLE
Update licensing.md - fix anchors

### DIFF
--- a/_docs/resources/licensing.md
+++ b/_docs/resources/licensing.md
@@ -32,8 +32,8 @@ Overall there are 3 types of licenses which you can use:
 
 And 3 types which you cannot use in any way:
 
-* [Code licensed under AGPL or variants thereof](#Code-licensed-under-AGPL-or-variants-thereof)
-* [Commons Clause licensed code](#Guidance-on-Commons-Clause-and-similar)
+* [Code licensed under AGPL or variants thereof](#code-licensed-under-agpl-or-variants-thereof)
+* [Commons Clause licensed code](#guidance-on-commons-clause-and-similar)
 * [Unlicensed code](#unlicensed-code)
 
 


### PR DESCRIPTION
Issue: # 

## Description

Link anchors with capital letters (like in https://opensource.zalando.com/docs/resources/licensing/#Code-licensed-under-AGPL-or-variants-thereof) are accessible in GitHub, but do not work properly on the website. 
While this could be solved on the code level by fixing URL dispatching logic, I am not sure I'd be able to tackle this.
Simple solution for this page - to fix anchors on this page. Lowercased links both working on GitHub and on a static-generated website.

## Types of Changes

_What types of changes does your code introduce? remove the points which aren't applicable:_

- Refactor/improvements

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply:_

- [x] My change requires a change to the documentation & I have updated it accordingly.
