### PR TITLE
Updating link to point straight to innersourcecommons.org

### DIFF
--- a/_docs/resources/innersource-howto.md
+++ b/_docs/resources/innersource-howto.md
@@ -49,6 +49,6 @@ The original team.
 There's a growing number of useful resources on InnerSource. Here are a few:
 - O'Reilly/PayPal's [Getting Started With InnerSource](https://www.oreilly.com/ideas/getting-started-with-innersource) booklet
 - [Adopting Open Source Development Practices in Organizations: A Tutorial](http://ieeexplore.ieee.org/document/6809709/) by the IEEE (requires sign-in)
-- [InnerSource Commons](https://paypal.github.io/InnerSourceCommons/) website
+- [InnerSource Commons](http://innersourcecommons.org) website
 - [Inner Source in Platform-Based Product
 Engineering](https://dirkriehle.com/wp-content/uploads/2016/06/riehle-capraro-horn-kips-inner-source-in-product-line-engineering-platform-based-products.pdf) by Drs. Dirk Riehle, Maximilian Capraro, Detlef Kips, Lars Horn


### PR DESCRIPTION
Issue: no issue

## Description

The InnerSource Commons is now a cross-company initiative by many companies (in fact even a Foundation), and no longer directly tied to PayPal. The content that used to live at https://paypal.github.io/InnerSourceCommons/ has been released as a standalone website at http://innersourcecommons.org.

Therefore I updated the link to point straight to innersourcecommons.org

## Types of Changes

_What types of changes does your code introduce? remove the points which aren't applicable:_

- Bug fix (non-breaking change which fixes an issue)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply:_

- [x] My change requires a change to the documentation & I have updated it accordingly.

