### PR TITLE
Make the link to the first page work

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -9,6 +9,8 @@
   {% for page in (1..paginator.total_pages) %}
     {% if page == paginator.page %}
       <span class="pagination__link pagination__link--active">{{ page }}</span>
+    {% elsif page == 1 %}
+      <a class="pagination__link" href="{{ site.paginate_path | prepend: site.baseurl | replace: 'page:num', '' | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a class="pagination__link" href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
Issue #424 - First link in the blog pagination is broken

## Description

First link in the blog pagination points to:
https://opensource.zalando.com/blog/page1/
and returns 404.

This is a [known issue](https://jekyllrb.com/docs/pagination/#render-the-paginated-posts) in Jekyll. This PR modifies the link URL so instead of `/blog/page1/` it now points to `/blog/`.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Tasks

  - [x] Fix the pagination link to the first page

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply:_

- [ ] My change requires a change to the documentation & I have updated it accordingly.

## Screenshots/Videos (OPTIONAL)

<img width="731" alt="image" src="https://user-images.githubusercontent.com/152606/186992216-223d34e9-2d55-4b71-881d-52ea30b54eaf.png">
