### PR TITLE
internal #10: Clarify when Zalando owns your work

### DIFF
--- a/_docs/using/contributing.md
+++ b/_docs/using/contributing.md
@@ -7,7 +7,7 @@ banner:
 category: Using
 ---
 
-#### We encourage participation in open source projects and strive to have as few rules for this as possible, we expect Zalandos to follow common sense on what code and information they contribute - if in doubt, contact the open source team, or talk to your lead.
+#### We encourage participation in open source projects and strive to have as few rules for this as possible, we expect Zalandos to follow common sense on what code and information they contribute – if in doubt, contact the open source team, or talk to your lead.
 
 ### Summary
 
@@ -19,14 +19,16 @@ category: Using
 
 ---
 
+The following applies if you do the contribution in the [context of work at Zalando](employee-copyright.md), as then Zalando owns the copyright on your works.
+
 ## Common contribution rules
 
 * Do not share customer data or confidential Zalando information
-* Code that cannot be contributed upstream
+* Code that cannot be contributed upstream:
   * confidential source code
   * recommendation algorithms
   * search functionalities that give us an edge over competitors
-* Remember that Zalando legally have ownership over your contributions as you are an employee of Zalando SE
+
 
 ## Non-code contributions
 

--- a/_docs/using/employee-copyright.md
+++ b/_docs/using/employee-copyright.md
@@ -1,0 +1,77 @@
+---
+title: Works by Zalando Employees
+author: Paul Ebermann
+date: 2022-10-25
+category: Using
+banner:
+  image: fence.jpg
+---
+
+_This is partially extracted from our internal Open Source Training documentation._
+
+
+## When does Zalando own your work?
+
+For the legal definition, have a look into your employment contract, but it usually says something like this.
+
+In any of the following three (often overlapping) cases, works created by employees (or rather, exclusive copyright on them) are owned by the employer:
+
+### The work is in connection with business-activities
+
+The work is part of fulfilling your job role. It might not be a direct output of your role, but also work which was needed to be able to get your daily tasks done.
+
+### The work is part of an agreed upon assignment at Zalando
+
+Your lead told you to create this, you might have worked on it in your personal time, but it is still the property of Zalando as it is a work assignment.
+
+### The work is done with Zalando resources or materials
+
+You spend time during work hours, you used servers or cloud services paid for by Zalando, used Zalando data or other Zalando intellectual property or used other company resources such as marketing or sales.
+
+## When does Zalando not own your work?
+
+If you work on your own time, on your own computer (and using also no other Zalando resources), on a non-Zalando-related project, Zalando generally has no rights on your creations.
+
+Avoid grey areas, where the ownership is not clear.
+
+## Copyright scenarios by project
+
+###  github.com/you/widgetproject
+
+(your personal project)
+
+* Work on your personal time
+
+* Avoid it overlapping with assignments
+* Avoid it overlapping with your job role
+* Avoid use of company data and IP
+* Avoid use of company resources
+
+**The project is your property.**
+If you get contributions from others, those are property of the contributors, though usually you should require them to at least license them to you.
+
+### github.com/facebook/react
+
+(a project of someone else)
+
+* You can work on it in your personal time
+* Can be part of work – ask your lead (and follow the [guidelines](contributing.md)).
+
+* Avoid use of company data and IP
+* Be aware of CLAs.
+    * If it's touching the "Zalando owns your work" areas mentioned above, you are only allowed to sign [approved CLAs](employee-copyright.md#allowlisted-clas).
+    * If it's your own work, you should still read the CLA, and make sure you don't sign over rights you don't have (or don't want to give).
+
+
+**The project is property of its owner.**
+Your contribution is your property (but generally at least licensed to the project (and other users) under some license, and often a CLA requires you to assign copyright to the owner).
+
+### github.com/zalando/patroni
+
+(a Zalando project)
+
+* You can work on it in your personal time.
+* Can be part of work – ask your lead.
+
+**The project is property of Zalando.**
+Your contribution is your property, but licensed to Zalando (and all other users) under MIT License.


### PR DESCRIPTION
Issue: https://github.bus.zalan.do/opensource/issues/issues/10 (internal)

## Description

As discussed in the recent Open Source Community of Practice meeting, the current »Remember that Zalando legally have ownership over your contributions as you are an employee of Zalando SE« on the [Contributing upstream](https://opensource.zalando.com/docs/using/contributing/) page is a bit unclear.

This PR adds a page detailing the scenarios when Zalando owns the contribution and when not. The content is mostly copied from the [Open Source onboarding presentation](https://docs.google.com/presentation/d/1IzqWfOvG3iRy882VLypyuXBHW7ynd4ErV3BHu5vPCm8/edit#slide=id.g40d1653207_0_11) (internal link), slightly reworded by me.

## Types of Changes

_What types of changes does your code introduce? Remove the points which aren't applicable:_

- new page
- small change in another page

