### PR TITLE
Updates owning team name

### DIFF
--- a/.zappr.yml
+++ b/.zappr.yml
@@ -1,2 +1,2 @@
 X-Zalando-Type: doc
-X-Zalando-Team: opensource
+X-Zalando-Team: zcpe


### PR DESCRIPTION
ComPR complains about zappr.yaml being invalid. This PR updates owning team name to an existing team.