### PR TITLE
docs: fix typos and grammar in 2018/2019 open source reports

### DIFF
--- a/_docs/reports/2018/components/contributors.html
+++ b/_docs/reports/2018/components/contributors.html
@@ -1,7 +1,7 @@
 <h1 class="dc-h1 page-section__header dc--text-center">Top contributors</h1>
 
 <p class="dc-p strategy__subtitle dc--text-center">
-  While open source is encouraged at Zalando, it is a small number of contributors who drives
+  While open source is encouraged at Zalando, it is a small number of contributors who drive
   the majority of all open source contributions.
 
   Just <b>17 Zalando employees are responsible for 50%</b> of all commits made, and <b>80% of all open

--- a/_docs/reports/2018/components/roadmap.html
+++ b/_docs/reports/2018/components/roadmap.html
@@ -1,14 +1,14 @@
 <h1 class="dc-h1 page-section__header">Roadmap</h1>
 
 <p class="dc-p strategy__subtitle">
-  Our goal is to grow and professionalise Zalandos open source efforts, to increase our community
+  Our goal is to grow and professionalise Zalando's open source efforts, to increase our community
   reach and thereby increase the pool of potential high-quality hires. To do so, we must have high quality
   open source offerings and dedicated maintainers.
 </p>
 
 <p class="dc-p strategy__subtitle">
-  The next 6 months, the Open Source team is focused on <b>creating clearity</b> of Zalando open source policies,
-  <b>remove barriers</b> of entry and <b>spread the culture</b> of open source among current maintainers and new hires.
+  The next 6 months, the Open Source team is focused on <b>creating clarity</b> of Zalando open source policies,
+  <b>removing barriers</b> of entry and <b>spreading the culture</b> of open source among current maintainers and new hires.
 </p>
 
 <div class="timeline">
@@ -23,7 +23,7 @@
         <div class="timeline__content timeline__content--left">
           <div class="dc-h4 timeline__title">Single source of truth</div>
           <div class="timeline__description">
-            Restructure and clearify process and policy documents to remove any uncertainty of Zalandos open source strategy
+            Restructure and clarify process and policy documents to remove any uncertainty of Zalando's open source strategy
           </div>
         </div>
       </div>
@@ -94,7 +94,7 @@
           <div class="dc-h4 timeline__title">Policy and Rules Of Play</div>
           <div class="timeline__description">
             Align our policies to remove barriers and uncertainty. Work with legal, compliance and
-            Zonar teams to improve our polices and legal contracts
+            Zonar teams to improve our policies and legal contracts
           </div>
         </div>
       </div>

--- a/_docs/reports/2019/components/checklist.html
+++ b/_docs/reports/2019/components/checklist.html
@@ -1,8 +1,8 @@
 <h1 class="dc-h1 page-section__header">Past 6 months</h1>
 
 <p class="dc-p strategy__subtitle">
-  The past 6 months, the Open Source team has been focused on <b>creating clearity</b> of Zalando open source policies,
-  <b>remove barriers</b> of entry and <b>spread the culture</b> of open source among current maintainers and new hires.
+  The past 6 months, the Open Source team has been focused on <b>creating clarity</b> of Zalando open source policies,
+  <b>removing barriers</b> of entry and <b>spreading the culture</b> of open source among current maintainers and new hires.
   The list below is the open source team's roadmap for second half of 2018 along with a status of each task. 
 </p>
 
@@ -18,7 +18,7 @@
         <div class="timeline__content timeline__content--left">
           <div class="dc-h4 timeline__title">Single source of truth - <strong>done</strong></div>
           <div class="timeline__description">
-            Restructure and clearify process and policy documents to remove any uncertainty of Zalandos open source strategy
+            Restructure and clarify process and policy documents to remove any uncertainty of Zalando's open source strategy
             <br><br><strong>Website launched May 2018 - updated on a weekly basis</strong>
           </div>
         </div>
@@ -98,7 +98,7 @@
           <div class="dc-h4 timeline__title">Policy and Rules Of Play - <strong>Not complete</strong></div>
           <div class="timeline__description">
             Align our policies to remove barriers and uncertainty. Work with legal, compliance and
-            Zonar teams to improve our polices and legal contracts
+            Zonar teams to improve our policies and legal contracts
             <br><br><strong>While internal developer ruleset has been updated we still see room for improvements in regards to how ownership and copyright is managed</strong>
           </div>
         </div>

--- a/_docs/reports/2019/components/contributors.html
+++ b/_docs/reports/2019/components/contributors.html
@@ -1,7 +1,7 @@
 <h1 class="dc-h1 page-section__header dc--text-center">Top contributors in 2018</h1>
 
 <p class="dc-p strategy__subtitle dc--text-center">
-  While open source is encouraged at Zalando, it is a small number of contributors who drives
+  While open source is encouraged at Zalando, it is a small number of contributors who drive
   the majority of all open source contributions.
 
   Just <b>17 Zalando employees are responsible for 50%</b> of all commits made, and <b>80% of all open

--- a/_docs/reports/2019/components/projects.html
+++ b/_docs/reports/2019/components/projects.html
@@ -5,8 +5,8 @@
     Pytorch. <a class="dc-link" href="https://github.com/zalandoresearch/famos">Famos</a>, an adversarial framework for image stylization and 
     <a class="dc-link" href="https://github.com/zalando-incubator/darty">Darty</a>, a data dependency manager. 
 <br><br>
-    3 projects related to our work with Kubernetes was released during 2018: <a class="dc-link" href="https://github.com/zalando-incubator/aluster-lifecycle-manager">Cluster-lifecycle-manager</a>, 
-    to provision multiple kubernetes clusters, <a class="dc-link" href="https://github.com/zalando-incubator/stackset-controller">Stackset-controller</a>, a kubernetes resource lifecycle manager 
+    3 projects related to our work with Kubernetes were released during 2018: <a class="dc-link" href="https://github.com/zalando-incubator/aluster-lifecycle-manager">Cluster-lifecycle-manager</a>, 
+    to provision multiple Kubernetes clusters, <a class="dc-link" href="https://github.com/zalando-incubator/stackset-controller">Stackset-controller</a>, a Kubernetes resource lifecycle manager 
     and <a class="dc-link" href="https://github.com/zalando-incubator/kube-metrics-adapter">Kube-metrics-adapter</a> for Kubernetes HPA metrics collection.
     <br><br>
     The Zalando open source team released <a class="dc-link" href="https://github.com/zalando/zalando.github.io">documentation</a> and 

--- a/_docs/reports/2019/components/roadmap.html
+++ b/_docs/reports/2019/components/roadmap.html
@@ -49,7 +49,7 @@
         <div class="timeline__content timeline__content--left">
           <div class="dc-h4 timeline__title">Giving Back</div>
           <div class="timeline__description">
-            Continue to push contributions to upstream projects and release high-quality work back to open source community. 
+            Continue to push contributions to upstream projects and release high-quality work back to the open source community. 
             Encourage engineering leaders to hire community contributors 
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fix 15 issues across 6 files in the 2018 and 2019 open source report components:

- `_docs/reports/2019/components/projects.html`: was → were (subject-verb agreement); kubernetes → Kubernetes (proper noun, 2 instances)
- `_docs/reports/2019/components/checklist.html`: clearity → clarity; remove/spread → removing/spreading (parallel construction); clearify → clarify; Zalandos → Zalando's; polices → policies
- `_docs/reports/2019/components/contributors.html`: drives → drive (subject-verb agreement)
- `_docs/reports/2019/components/roadmap.html`: added missing article "the" before "open source community"
- `_docs/reports/2018/components/roadmap.html`: clearity → clarity; remove/spread → removing/spreading; clearify → clarify; Zalandos → Zalando's (2 instances); polices → policies
- `_docs/reports/2018/components/contributors.html`: drives → drive (subject-verb agreement)

No functional changes -- comments and documentation only.